### PR TITLE
Use prettier configuration from prettier-config-keep

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,9 @@ module.exports = {
     "require-jsdoc": 0,
 
     "no-only-tests/no-only-tests": "error",
-    "prettier/prettier": ["error", { semi: false }]
+    "prettier/prettier": [
+      "error",
+      require("@keep-network/prettier-config-keep")
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       }
     },
     "@keep-network/prettier-config-keep": {
-      "version": "github:keep-network/prettier-config-keep#43e56710fa603397c603f0d3e890c044e79073f2",
+      "version": "github:keep-network/prettier-config-keep#d6ec02e80dd76edfba073ca58ef99aee39002c2c",
       "from": "github:keep-network/prettier-config-keep"
     },
     "@types/color-name": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,10 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@keep-network/prettier-config-keep": {
+      "version": "github:keep-network/prettier-config-keep#43e56710fa603397c603f0d3e890c044e79073f2",
+      "from": "github:keep-network/prettier-config-keep"
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -284,9 +288,9 @@
       "integrity": "sha512-ELgMdOIpn0CFdsQS+FuxO+Ttu4p+aLaXHv9wA9yVnzqlUGV7oN/eRRnJekk7TCur6Cu2FXX0fqfIXRBaM14lpQ=="
     },
     "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
       "requires": {
         "get-stdin": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
     "prettier": "^1.19.1"
   },
   "dependencies": {
+    "@keep-network/prettier-config-keep": "github:keep-network/prettier-config-keep",
     "eslint-config-google": "^0.13.0",
+    "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-no-only-tests": "^2.3.1",
-    "eslint-plugin-prettier": "^3.1.2",
-    "eslint-config-prettier": "^6.10.0"
+    "eslint-plugin-prettier": "^3.1.2"
   }
 }


### PR DESCRIPTION
The package [prettier-config-keep](https://github.com/keep-network/prettier-config-keep) holds the common prettier configuration
we use across our repos. Here we pull that configuration to be used also in eslint.