### PR TITLE
Don't look for the config files in parent directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ module.exports = {
 
   plugins: ["no-only-tests", "prettier"],
 
+  root: true,
+
   rules: {
     "new-cap": [
       "error",


### PR DESCRIPTION
The `root: true` config was added to the `module.exports` in order to
prevent the ESLint from searching parent directories for `.eslintrc.*`
configuration files. Only the current directory will be searched.